### PR TITLE
UserSession null/undefined in ajaxSetup

### DIFF
--- a/addon/services/session.js
+++ b/addon/services/session.js
@@ -172,9 +172,9 @@ export default Service.extend({
 
     $.ajaxSetup({
       beforeSend: (xhr, settings) => {
-        let userSession = this.get('userSession');
-        if (userSession.access_token && !settings.ignoreAuthorizationHeader) {
-          xhr.setRequestHeader('Authorization', `Bearer ${userSession.access_token}`);
+        let accessToken = this.get('userSession.access_token');
+        if (accessToken && !settings.ignoreAuthorizationHeader) {
+          xhr.setRequestHeader('Authorization', `Bearer ${accessToken}`);
         }
       }
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-practical-oidc",
-  "version": "0.0.0-beta.4",
+  "version": "0.0.0-beta.5",
   "description": "An addon that encapsulates a way to interact with an OIDC server using Ember.js.",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
- Gets the access_token directly from get('userSession.access_token') so that it'll be undefined if there's an error and won't add the authorization bearer. (Problem was that userSession was null, so null.access_token == :boom:)